### PR TITLE
Fix iPad responsiveness across the app

### DIFF
--- a/EventPassUG/Features/Attendee/PaymentConfirmationView.swift
+++ b/EventPassUG/Features/Attendee/PaymentConfirmationView.swift
@@ -68,6 +68,7 @@ struct PaymentConfirmationView: View {
                 )
             }
         }
+        .navigationViewStyle(.stack)
     }
 
     // MARK: - Header Section

--- a/EventPassUG/Features/Attendee/TicketDetailView.swift
+++ b/EventPassUG/Features/Attendee/TicketDetailView.swift
@@ -181,28 +181,33 @@ struct TicketDetailView: View {
                                     .foregroundColor(.secondary)
                             }
 
-                            // QR Code
-                            if let qrImage = QRCodeGenerator.generate(
-                                from: ticket.qrCodeData,
-                                size: CGSize(width: 280, height: 280)
-                            ) {
-                                VStack(spacing: AppSpacing.md) {
-                                    Image(uiImage: qrImage)
-                                        .interpolation(.none)
-                                        .resizable()
-                                        .frame(width: 280, height: 280)
-                                        .padding(AppSpacing.lg)
-                                        .background(Color.white)
-                                        .cornerRadius(AppCornerRadius.medium)
-                                        .shadow(color: .black.opacity(0.1), radius: 10)
+                            // QR Code - Responsive sizing
+                            GeometryReader { geometry in
+                                let qrSize = min(geometry.size.width - AppSpacing.lg * 2, 280)
+                                if let qrImage = QRCodeGenerator.generate(
+                                    from: ticket.qrCodeData,
+                                    size: CGSize(width: qrSize, height: qrSize)
+                                ) {
+                                    VStack(spacing: AppSpacing.md) {
+                                        Image(uiImage: qrImage)
+                                            .interpolation(.none)
+                                            .resizable()
+                                            .frame(width: qrSize, height: qrSize)
+                                            .padding(AppSpacing.lg)
+                                            .background(Color.white)
+                                            .cornerRadius(AppCornerRadius.medium)
+                                            .shadow(color: .black.opacity(0.1), radius: 10)
 
-                                    Text(ticket.qrCodeData.suffix(12).uppercased())
-                                        .font(AppTypography.caption)
-                                        .monospaced()
-                                        .foregroundColor(.secondary)
+                                        Text(ticket.qrCodeData.suffix(12).uppercased())
+                                            .font(AppTypography.caption)
+                                            .monospaced()
+                                            .foregroundColor(.secondary)
+                                    }
+                                    .frame(maxWidth: .infinity)
                                 }
-                                .frame(maxWidth: .infinity)
                             }
+                            .aspectRatio(1, contentMode: .fit)
+                            .frame(maxWidth: 320)
                         }
 
                         // Rating section for expired tickets
@@ -331,6 +336,7 @@ struct TicketDetailView: View {
                 }
             }
         }
+        .navigationViewStyle(.stack)
         .alert("Rating Submitted", isPresented: $showingRatingConfirmation) {
             Button("OK", role: .cancel) { }
         } message: {

--- a/EventPassUG/Features/Attendee/TicketPurchaseView.swift
+++ b/EventPassUG/Features/Attendee/TicketPurchaseView.swift
@@ -236,6 +236,7 @@ struct TicketPurchaseView: View {
                 }
             }
         }
+        .navigationViewStyle(.stack)
         .sheet(isPresented: $showingPaymentConfirmation) {
             PaymentConfirmationView(
                 event: event,

--- a/EventPassUG/Features/Attendee/TicketSuccessView.swift
+++ b/EventPassUG/Features/Attendee/TicketSuccessView.swift
@@ -114,20 +114,26 @@ struct TicketSuccessView: View {
 
                         ForEach(tickets) { ticket in
                             VStack(spacing: AppSpacing.md) {
-                                // QR Code
-                                if let qrImage = QRCodeGenerator.generate(
-                                    from: ticket.qrCodeData,
-                                    size: CGSize(width: 250, height: 250)
-                                ) {
-                                    Image(uiImage: qrImage)
-                                        .interpolation(.none)
-                                        .resizable()
-                                        .frame(width: 250, height: 250)
-                                        .padding()
-                                        .background(Color.white)
-                                        .cornerRadius(AppCornerRadius.medium)
-                                        .shadow(color: .black.opacity(0.1), radius: 10)
+                                // QR Code - Responsive sizing
+                                GeometryReader { geometry in
+                                    let qrSize = min(geometry.size.width - AppSpacing.lg * 2, 280)
+                                    if let qrImage = QRCodeGenerator.generate(
+                                        from: ticket.qrCodeData,
+                                        size: CGSize(width: qrSize, height: qrSize)
+                                    ) {
+                                        Image(uiImage: qrImage)
+                                            .interpolation(.none)
+                                            .resizable()
+                                            .frame(width: qrSize, height: qrSize)
+                                            .padding()
+                                            .background(Color.white)
+                                            .cornerRadius(AppCornerRadius.medium)
+                                            .shadow(color: .black.opacity(0.1), radius: 10)
+                                            .frame(maxWidth: .infinity)
+                                    }
                                 }
+                                .aspectRatio(1, contentMode: .fit)
+                                .frame(maxWidth: 320)
 
                                 // Ticket ID
                                 Text(ticket.id.uuidString.prefix(8).uppercased())
@@ -198,6 +204,7 @@ struct TicketSuccessView: View {
                 }
             }
         }
+        .navigationViewStyle(.stack)
     }
 }
 

--- a/EventPassUG/Features/Auth/AddContactMethodView.swift
+++ b/EventPassUG/Features/Auth/AddContactMethodView.swift
@@ -124,6 +124,7 @@ struct AddContactMethodView: View {
                 }
             }
         }
+        .navigationViewStyle(.stack)
         .sheet(isPresented: $showPhoneVerification) {
             if verificationId != nil {
                 PhoneVerificationView(phoneNumber: phoneNumber) {

--- a/EventPassUG/Features/Auth/PhoneVerificationView.swift
+++ b/EventPassUG/Features/Auth/PhoneVerificationView.swift
@@ -150,6 +150,7 @@ struct PhoneVerificationView: View {
                 }
             }
         }
+        .navigationViewStyle(.stack)
         .alert("Phone Verified", isPresented: $showSuccess) {
             Button("Done") {
                 onVerified?()

--- a/EventPassUG/Features/Common/CalendarConflictView.swift
+++ b/EventPassUG/Features/Common/CalendarConflictView.swift
@@ -48,6 +48,7 @@ struct CalendarConflictView: View {
                 }
             }
         }
+        .navigationViewStyle(.stack)
     }
 
     // MARK: - Components

--- a/EventPassUG/Features/Common/EditProfileView.swift
+++ b/EventPassUG/Features/Common/EditProfileView.swift
@@ -383,6 +383,7 @@ struct UpdateEmailView: View {
                 }
             }
         }
+        .navigationViewStyle(.stack)
         .alert("Verification Sent", isPresented: $showSuccess) {
             Button("OK") {
                 dismiss()
@@ -491,6 +492,7 @@ struct UpdatePhoneView: View {
                 }
             }
         }
+        .navigationViewStyle(.stack)
         .alert("Phone Updated", isPresented: $showSuccess) {
             Button("OK") {
                 dismiss()

--- a/EventPassUG/Features/Common/FavoriteEventCategoriesView.swift
+++ b/EventPassUG/Features/Common/FavoriteEventCategoriesView.swift
@@ -266,6 +266,7 @@ struct FavoriteEventCategoriesView: View {
             .navigationTitle("")
             .navigationBarTitleDisplayMode(.inline)
         }
+        .navigationViewStyle(.stack)
     }
 
     private var onboardingHeader: some View {

--- a/EventPassUG/Features/Common/NationalIDVerificationView.swift
+++ b/EventPassUG/Features/Common/NationalIDVerificationView.swift
@@ -278,6 +278,7 @@ struct NationalIDVerificationView: View {
                 }
             }
         }
+        .navigationViewStyle(.stack)
         .alert("Verification Submitted", isPresented: $showSuccess) {
             Button("OK") {
                 dismiss()

--- a/EventPassUG/Features/Common/NotificationsView.swift
+++ b/EventPassUG/Features/Common/NotificationsView.swift
@@ -43,6 +43,7 @@ struct NotificationsView: View {
                 }
             }
         }
+        .navigationViewStyle(.stack)
     }
 
     private func markAllAsRead() {

--- a/EventPassUG/Features/Common/PaymentMethodsView.swift
+++ b/EventPassUG/Features/Common/PaymentMethodsView.swift
@@ -281,6 +281,7 @@ struct AddPaymentMethodView: View {
                 }
             }
         }
+        .navigationViewStyle(.stack)
         .onAppear {
             if let phone = authService.currentUser?.phoneNumber {
                 mobileMoneyNumber = phone

--- a/EventPassUG/Features/Common/ProfileViewExtensions.swift
+++ b/EventPassUG/Features/Common/ProfileViewExtensions.swift
@@ -319,6 +319,7 @@ struct EmailVerificationSheet: View {
                 }
             }
         }
+        .navigationViewStyle(.stack)
         .alert("Email Sent!", isPresented: $showSuccess) {
             Button("OK") {
                 dismiss()
@@ -452,6 +453,7 @@ struct AccountLinkingView: View {
                 }
             }
         }
+        .navigationViewStyle(.stack)
         .alert("Account Linked!", isPresented: $showSuccess) {
             Button("OK") {}
         } message: {

--- a/EventPassUG/Features/Organizer/BecomeOrganizerFlow.swift
+++ b/EventPassUG/Features/Organizer/BecomeOrganizerFlow.swift
@@ -57,6 +57,7 @@ struct BecomeOrganizerFlow: View {
                 Text("You're now an Organizer! Would you like to switch to Organizer Mode now?")
             }
         }
+        .navigationViewStyle(.stack)
     }
 
     @ViewBuilder

--- a/EventPassUG/Features/Organizer/CreateEventWizard.swift
+++ b/EventPassUG/Features/Organizer/CreateEventWizard.swift
@@ -168,6 +168,7 @@ struct CreateEventWizard: View {
                 }
             }
         }
+        .navigationViewStyle(.stack)
         .alert(isEditingExistingEvent ? "Event Updated!" : "Event Published!", isPresented: $showingSuccessAlert) {
             Button("Done") {
                 dismiss()

--- a/EventPassUG/Features/Organizer/ManageEventTicketsView.swift
+++ b/EventPassUG/Features/Organizer/ManageEventTicketsView.swift
@@ -94,6 +94,7 @@ struct ManageEventTicketsView: View {
                 }
             }
         }
+        .navigationViewStyle(.stack)
     }
 
     // MARK: - Sections

--- a/EventPassUG/Features/Organizer/OrganizerHomeView.swift
+++ b/EventPassUG/Features/Organizer/OrganizerHomeView.swift
@@ -44,6 +44,7 @@ struct OrganizerHomeView: View {
                     .environmentObject(authService)
             }
         }
+        .navigationViewStyle(.stack)
         .onAppear {
             loadEvents()
             subscribeToTicketSales()

--- a/EventPassUG/Features/Organizer/OrganizerIdentityVerificationStep.swift
+++ b/EventPassUG/Features/Organizer/OrganizerIdentityVerificationStep.swift
@@ -101,6 +101,7 @@ struct OrganizerIdentityVerificationStep: View {
                 NationalIDVerificationView()
                     .environmentObject(authService)
             }
+            .navigationViewStyle(.stack)
         }
     }
 

--- a/EventPassUG/Features/Organizer/OrganizerNotificationCenterView.swift
+++ b/EventPassUG/Features/Organizer/OrganizerNotificationCenterView.swift
@@ -70,6 +70,7 @@ struct OrganizerNotificationCenterView: View {
             }
             .navigationBarHidden(true)
         }
+        .navigationViewStyle(.stack)
         .onAppear {
             loadNotifications()
         }

--- a/EventPassUG/Features/Organizer/OrganizerProfileCompletionStep.swift
+++ b/EventPassUG/Features/Organizer/OrganizerProfileCompletionStep.swift
@@ -111,18 +111,21 @@ struct OrganizerProfileCompletionStep: View {
                 EditProfileView()
                     .environmentObject(authService)
             }
+            .navigationViewStyle(.stack)
         }
         .sheet(isPresented: $showEmailVerification) {
             NavigationView {
                 EmailVerificationView()
                     .environmentObject(authService)
             }
+            .navigationViewStyle(.stack)
         }
         .sheet(isPresented: $showPhoneVerification) {
             NavigationView {
                 OrganizerPhoneVerificationView()
                     .environmentObject(authService)
             }
+            .navigationViewStyle(.stack)
         }
     }
 

--- a/EventPassUG/Features/Organizer/QRScannerView.swift
+++ b/EventPassUG/Features/Organizer/QRScannerView.swift
@@ -30,38 +30,41 @@ struct QRScannerView: View {
                     .edgesIgnoringSafeArea(.all)
 
                 // Overlay UI
-                VStack {
-                    Spacer()
+                GeometryReader { geometry in
+                    let frameSize = min(geometry.size.width - 80, 280)
+                    VStack {
+                        Spacer()
 
-                    // Scanning frame
-                    RoundedRectangle(cornerRadius: 20)
-                        .stroke(Color.white, lineWidth: 3)
-                        .frame(width: 280, height: 280)
-                        .overlay(
-                            VStack {
-                                ForEach(0..<4) { _ in
-                                    Rectangle()
-                                        .fill(Color.white.opacity(0.3))
-                                        .frame(height: 2)
-                                        .padding(.vertical, 20)
+                        // Scanning frame - Responsive
+                        RoundedRectangle(cornerRadius: 20)
+                            .stroke(Color.white, lineWidth: 3)
+                            .frame(width: frameSize, height: frameSize)
+                            .overlay(
+                                VStack {
+                                    ForEach(0..<4) { _ in
+                                        Rectangle()
+                                            .fill(Color.white.opacity(0.3))
+                                            .frame(height: 2)
+                                            .padding(.vertical, 20)
+                                    }
                                 }
-                            }
-                        )
+                            )
 
-                    Spacer()
+                        Spacer()
 
-                    // Instructions
-                    VStack(spacing: AppSpacing.sm) {
-                        Text("Scan QR Code")
-                            .font(AppTypography.title3)
-                            .fontWeight(.bold)
-                            .foregroundColor(.white)
+                        // Instructions
+                        VStack(spacing: AppSpacing.sm) {
+                            Text("Scan QR Code")
+                                .font(AppTypography.title3)
+                                .fontWeight(.bold)
+                                .foregroundColor(.white)
 
-                        Text("Position the QR code within the frame")
-                            .font(AppTypography.callout)
-                            .foregroundColor(.white.opacity(0.8))
+                            Text("Position the QR code within the frame")
+                                .font(AppTypography.callout)
+                                .foregroundColor(.white.opacity(0.8))
+                        }
+                        .padding(.bottom, AppSpacing.xxl)
                     }
-                    .padding(.bottom, AppSpacing.xxl)
                 }
 
                 // Result overlay
@@ -94,6 +97,7 @@ struct QRScannerView: View {
             }
             .toolbarBackground(.hidden, for: .navigationBar)
         }
+        .navigationViewStyle(.stack)
         .onChange(of: scannedCode) { newValue in
             guard let code = newValue, isScanning else { return }
             isScanning = false

--- a/EventPassUG/Features/Scanner/ScannerConnectView.swift
+++ b/EventPassUG/Features/Scanner/ScannerConnectView.swift
@@ -344,64 +344,68 @@ struct QRScannerSheet: View {
 
                 // Camera preview would go here
                 // For now, show a mock scanner view
-                VStack(spacing: AppSpacing.lg) {
-                    Spacer()
+                GeometryReader { outerGeometry in
+                    let frameSize = min(outerGeometry.size.width - 80, 250)
+                    VStack(spacing: AppSpacing.lg) {
+                        Spacer()
 
-                    // Scanner frame
-                    RoundedRectangle(cornerRadius: AppCornerRadius.lg)
-                        .stroke(Color.white, lineWidth: 3)
-                        .frame(width: 250, height: 250)
-                        .overlay(
-                            // Corner accents
-                            GeometryReader { geometry in
-                                let size = geometry.size
-                                let cornerLength: CGFloat = 30
-                                let lineWidth: CGFloat = 4
+                        // Scanner frame - Responsive
+                        RoundedRectangle(cornerRadius: AppCornerRadius.lg)
+                            .stroke(Color.white, lineWidth: 3)
+                            .frame(width: frameSize, height: frameSize)
+                            .overlay(
+                                // Corner accents
+                                GeometryReader { geometry in
+                                    let size = geometry.size
+                                    let cornerLength: CGFloat = 30
+                                    let lineWidth: CGFloat = 4
 
-                                Path { path in
-                                    // Top left
-                                    path.move(to: CGPoint(x: 0, y: cornerLength))
-                                    path.addLine(to: CGPoint(x: 0, y: 0))
-                                    path.addLine(to: CGPoint(x: cornerLength, y: 0))
+                                    Path { path in
+                                        // Top left
+                                        path.move(to: CGPoint(x: 0, y: cornerLength))
+                                        path.addLine(to: CGPoint(x: 0, y: 0))
+                                        path.addLine(to: CGPoint(x: cornerLength, y: 0))
 
-                                    // Top right
-                                    path.move(to: CGPoint(x: size.width - cornerLength, y: 0))
-                                    path.addLine(to: CGPoint(x: size.width, y: 0))
-                                    path.addLine(to: CGPoint(x: size.width, y: cornerLength))
+                                        // Top right
+                                        path.move(to: CGPoint(x: size.width - cornerLength, y: 0))
+                                        path.addLine(to: CGPoint(x: size.width, y: 0))
+                                        path.addLine(to: CGPoint(x: size.width, y: cornerLength))
 
-                                    // Bottom right
-                                    path.move(to: CGPoint(x: size.width, y: size.height - cornerLength))
-                                    path.addLine(to: CGPoint(x: size.width, y: size.height))
-                                    path.addLine(to: CGPoint(x: size.width - cornerLength, y: size.height))
+                                        // Bottom right
+                                        path.move(to: CGPoint(x: size.width, y: size.height - cornerLength))
+                                        path.addLine(to: CGPoint(x: size.width, y: size.height))
+                                        path.addLine(to: CGPoint(x: size.width - cornerLength, y: size.height))
 
-                                    // Bottom left
-                                    path.move(to: CGPoint(x: cornerLength, y: size.height))
-                                    path.addLine(to: CGPoint(x: 0, y: size.height))
-                                    path.addLine(to: CGPoint(x: 0, y: size.height - cornerLength))
+                                        // Bottom left
+                                        path.move(to: CGPoint(x: cornerLength, y: size.height))
+                                        path.addLine(to: CGPoint(x: 0, y: size.height))
+                                        path.addLine(to: CGPoint(x: 0, y: size.height - cornerLength))
+                                    }
+                                    .stroke(RoleConfig.organizerPrimary, lineWidth: lineWidth)
                                 }
-                                .stroke(RoleConfig.organizerPrimary, lineWidth: lineWidth)
-                            }
-                        )
+                            )
 
-                    Text("Point camera at pairing QR code")
-                        .font(AppTypography.callout)
-                        .foregroundColor(.white)
-
-                    Spacer()
-
-                    // Torch toggle
-                    Button(action: { torchOn.toggle() }) {
-                        Image(systemName: torchOn ? "flashlight.on.fill" : "flashlight.off.fill")
-                            .font(.system(size: 24))
+                        Text("Point camera at pairing QR code")
+                            .font(AppTypography.callout)
                             .foregroundColor(.white)
-                            .padding()
-                            .background(Color.white.opacity(0.2))
-                            .clipShape(Circle())
-                    }
-                    .padding(.bottom, AppSpacing.xl)
 
-                    // Mock: Simulate successful scan after delay
-                    // In production, this would use AVCaptureSession
+                        Spacer()
+
+                        // Torch toggle
+                        Button(action: { torchOn.toggle() }) {
+                            Image(systemName: torchOn ? "flashlight.on.fill" : "flashlight.off.fill")
+                                .font(.system(size: 24))
+                                .foregroundColor(.white)
+                                .padding()
+                                .background(Color.white.opacity(0.2))
+                                .clipShape(Circle())
+                        }
+                        .padding(.bottom, AppSpacing.xl)
+
+                        // Mock: Simulate successful scan after delay
+                        // In production, this would use AVCaptureSession
+                    }
+                    .frame(maxWidth: .infinity)
                 }
             }
             .navigationTitle("Scan QR Code")
@@ -439,31 +443,39 @@ struct TicketScannerView: View {
         ZStack {
             Color.black.ignoresSafeArea()
 
-            VStack(spacing: AppSpacing.lg) {
-                // Scanner frame
-                RoundedRectangle(cornerRadius: AppCornerRadius.lg)
-                    .stroke(viewModel.lastResult?.isSuccess == true ? Color.green :
-                            viewModel.lastResult != nil ? Color.red : Color.white,
-                            lineWidth: 3)
-                    .frame(width: 280, height: 280)
-                    .animation(.easeInOut(duration: 0.3), value: viewModel.lastResult?.status)
+            GeometryReader { geometry in
+                let frameSize = min(geometry.size.width - 80, 280)
+                VStack(spacing: AppSpacing.lg) {
+                    Spacer()
 
-                // Status display
-                if let result = viewModel.lastResult {
-                    ScanResultCard(result: result)
-                        .transition(.scale.combined(with: .opacity))
-                } else {
-                    Text("Scan ticket QR code")
-                        .font(AppTypography.callout)
-                        .foregroundColor(.white)
-                }
+                    // Scanner frame - Responsive
+                    RoundedRectangle(cornerRadius: AppCornerRadius.lg)
+                        .stroke(viewModel.lastResult?.isSuccess == true ? Color.green :
+                                viewModel.lastResult != nil ? Color.red : Color.white,
+                                lineWidth: 3)
+                        .frame(width: frameSize, height: frameSize)
+                        .animation(.easeInOut(duration: 0.3), value: viewModel.lastResult?.status)
 
-                // Stats
-                HStack(spacing: AppSpacing.xl) {
-                    StatDisplay(label: "Scanned", value: "\(viewModel.scanCount)")
-                    StatDisplay(label: "Valid", value: "\(viewModel.validCount)")
+                    // Status display
+                    if let result = viewModel.lastResult {
+                        ScanResultCard(result: result)
+                            .transition(.scale.combined(with: .opacity))
+                    } else {
+                        Text("Scan ticket QR code")
+                            .font(AppTypography.callout)
+                            .foregroundColor(.white)
+                    }
+
+                    // Stats
+                    HStack(spacing: AppSpacing.xl) {
+                        StatDisplay(label: "Scanned", value: "\(viewModel.scanCount)")
+                        StatDisplay(label: "Valid", value: "\(viewModel.validCount)")
+                    }
+                    .padding(.top, AppSpacing.lg)
+
+                    Spacer()
                 }
-                .padding(.top, AppSpacing.lg)
+                .frame(maxWidth: .infinity)
             }
         }
         .navigationTitle("Scanning")


### PR DESCRIPTION
   - Add .navigationViewStyle(.stack) to 22 NavigationView instances to prevent split-view behavior on iPad that causes layout issues
   - Make QR code displays responsive using GeometryReader with max width constraints (TicketSuccessView, TicketDetailView)
   - Make scanner frames responsive in QRScannerView and ScannerConnectView
   - All views now adapt properly to larger iPad screens while maintaining a maximum content width for readability